### PR TITLE
Fixing Product Fields in Sharp PPDs

### DIFF
--- a/db/source/PPD/Sharp/Sharp-AR-N182FG-ps-jp.ppd
+++ b/db/source/PPD/Sharp/Sharp-AR-N182FG-ps-jp.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHN182FJ.PPD"
-*Product: "(Sharp MX-NB12)"
+*Product: "(Sharp AR-N182FG)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-N182FG PS"
 *ShortNickName: "Sharp AR-N182FG PS"

--- a/db/source/PPD/Sharp/Sharp-AR-N182G-ps-jp.ppd
+++ b/db/source/PPD/Sharp/Sharp-AR-N182G-ps-jp.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHN182GJ.PPD"
-*Product: "(Sharp MX-NB12)"
+*Product: "(Sharp AR-N182G)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-N182G PS"
 *ShortNickName: "Sharp AR-N182G PS"

--- a/db/source/PPD/Sharp/Sharp-MX-M182-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M182-ps.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHMXM182.PPD"
-*Product: "(Sharp MX-NB12)"
+*Product: "(Sharp MX-M182)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp MX-M182 PS"
 *ShortNickName: "Sharp MX-M182 PS"

--- a/db/source/PPD/Sharp/Sharp-MX-M182D-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M182D-ps.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHMM182D.PPD"
-*Product: "(Sharp MX-NB12)"
+*Product: "(Sharp MX-M182D)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp MX-M182D PS"
 *ShortNickName: "Sharp MX-M182D PS"

--- a/db/source/PPD/Sharp/Sharp-MX-M202D-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M202D-ps.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHMM202D.PPD"
-*Product: "(Sharp MX-NB12)"
+*Product: "(Sharp MX-M202D)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp MX-M202D PS"
 *ShortNickName: "Sharp MX-M202D PS"

--- a/db/source/PPD/Sharp/Sharp-MX-M232D-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M232D-ps.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHMM232D.PPD"
-*Product: "(Sharp MX-NB12)"
+*Product: "(Sharp MX-M232D)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp MX-M232D PS"
 *ShortNickName: "Sharp MX-M232D PS"

--- a/db/source/PPD/Sharp/Sharp-MX-M260-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M260-ps.ppd
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-M256)"
+*Product: "(Sharp MX-M260)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/Sharp-MX-M260FP-ps-jp.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M260FP-ps-jp.ppd
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-M256)"
+*Product: "(Sharp MX-M260FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/Sharp-MX-M260N-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M260N-ps.ppd
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-M256)"
+*Product: "(Sharp MX-M260N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/Sharp-MX-M310-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M310-ps.ppd
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-M256)"
+*Product: "(Sharp MX-M310)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/Sharp-MX-M310FP-ps-jp.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M310FP-ps-jp.ppd
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-M256)"
+*Product: "(Sharp MX-M310FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/Sharp-MX-M310N-ps.ppd
+++ b/db/source/PPD/Sharp/Sharp-MX-M310N-ps.ppd
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-M256)"
+*Product: "(Sharp MX-M310N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sc170fpj.ppd
+++ b/db/source/PPD/Sharp/sc170fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SC170FPJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C170FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C170FP PS"
 *ShortNickName: "Sharp AR-C170FP PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C170FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sc172fpj.ppd
+++ b/db/source/PPD/Sharp/sc172fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SC172FPJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C172FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C172FP PS"
 *ShortNickName: "Sharp AR-C172FP PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C172FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sc260fpj.ppd
+++ b/db/source/PPD/Sharp/sc260fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SC260FPJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C260FP PS"
 *ShortNickName: "Sharp AR-C260FP PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sc261fpj.ppd
+++ b/db/source/PPD/Sharp/sc261fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SC261FPJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C261FP PS"
 *ShortNickName: "Sharp AR-C261FP PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sc262fpj.ppd
+++ b/db/source/PPD/Sharp/sc262fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SC262FPJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C262FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C262FP PS"
 *ShortNickName: "Sharp AR-C262FP PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C262FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh155fgj.ppd
+++ b/db/source/PPD/Sharp/sh155fgj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH155FGJ.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-155FG)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-155FG PS"
 *ShortNickName: "Sharp AR-155FG PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-155FG)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh160mj.ppd
+++ b/db/source/PPD/Sharp/sh160mj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH160MJ.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-160M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-160M PS"
 *ShortNickName: "Sharp AR-160M PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-160M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh163fgj.ppd
+++ b/db/source/PPD/Sharp/sh163fgj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH163FGJ.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-163FG)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-163FG PS"
 *ShortNickName: "Sharp AR-163FG PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-163FG)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh163gj.ppd
+++ b/db/source/PPD/Sharp/sh163gj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH163GJ.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-163G)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-163G PS"
 *ShortNickName: "Sharp AR-163G PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-163G)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh200mj.ppd
+++ b/db/source/PPD/Sharp/sh200mj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH200MJ.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-200M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-200M PS"
 *ShortNickName: "Sharp AR-200M PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-200M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh202fpj.ppd
+++ b/db/source/PPD/Sharp/sh202fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH202FPJ.PPD"
-*Product: "(Sharp AR-B07)"
+*Product: "(Sharp AR-N202FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-N202FP PS"
 *ShortNickName: "Sharp AR-N202FP PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-B07)"
+*Product: "(Sharp AR-N202FP)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh205fgj.ppd
+++ b/db/source/PPD/Sharp/sh205fgj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH205FGJ.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-205FG)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-205FG PS"
 *ShortNickName: "Sharp AR-205FG PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-205FG)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh205gj.ppd
+++ b/db/source/PPD/Sharp/sh205gj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH205GJ.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-205G)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-205G PS"
 *ShortNickName: "Sharp AR-205G PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-205G)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh266fpj.ppd
+++ b/db/source/PPD/Sharp/sh266fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH266FPJ.PPD"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-266FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-266FP PS"
 *ShortNickName: "Sharp AR-266FP PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-266FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh266sj.ppd
+++ b/db/source/PPD/Sharp/sh266sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH266SJ.PPD"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-266S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-266S PS"
 *ShortNickName: "Sharp AR-266S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-266S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh311fpj.ppd
+++ b/db/source/PPD/Sharp/sh311fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH311FPJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-311FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-311FP PS"
 *ShortNickName: "Sharp AR-311FP PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-311FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh311nj.ppd
+++ b/db/source/PPD/Sharp/sh311nj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH311NJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-311N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-311N PS"
 *ShortNickName: "Sharp AR-311N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-311N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh311sj.ppd
+++ b/db/source/PPD/Sharp/sh311sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH311SJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-311S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-311S PS"
 *ShortNickName: "Sharp AR-311S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-311S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh351fpj.ppd
+++ b/db/source/PPD/Sharp/sh351fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH351FPJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-351FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-351FP PS"
 *ShortNickName: "Sharp AR-351FP PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-351FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh351nj.ppd
+++ b/db/source/PPD/Sharp/sh351nj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH351NJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-351N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-351N PS"
 *ShortNickName: "Sharp AR-351N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-351N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh351sj.ppd
+++ b/db/source/PPD/Sharp/sh351sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH351SJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-351S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-351S PS"
 *ShortNickName: "Sharp AR-351S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-351S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh451fpj.ppd
+++ b/db/source/PPD/Sharp/sh451fpj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH451FPJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-451FP)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-451FP PS"
 *ShortNickName: "Sharp AR-451FP PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-451FP)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh451nj.ppd
+++ b/db/source/PPD/Sharp/sh451nj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH451NJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-451N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-451N PS"
 *ShortNickName: "Sharp AR-451N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-451N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh451sj.ppd
+++ b/db/source/PPD/Sharp/sh451sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH451SJ.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-451S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-451S PS"
 *ShortNickName: "Sharp AR-451S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-451S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh555mj.ppd
+++ b/db/source/PPD/Sharp/sh555mj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH555MJ.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-555M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-555M PS"
 *ShortNickName: "Sharp AR-555M PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-555M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh555sj.ppd
+++ b/db/source/PPD/Sharp/sh555sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH555SJ.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-555S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-555S PS"
 *ShortNickName: "Sharp AR-555S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-555S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh625mj.ppd
+++ b/db/source/PPD/Sharp/sh625mj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH625MJ.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-625M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-625M PS"
 *ShortNickName: "Sharp AR-625M PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-625M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh625sj.ppd
+++ b/db/source/PPD/Sharp/sh625sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH625SJ.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-625S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-625S PS"
 *ShortNickName: "Sharp AR-625S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-625S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh705mj.ppd
+++ b/db/source/PPD/Sharp/sh705mj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH705MJ.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-705M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-705M PS"
 *ShortNickName: "Sharp AR-705M PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-705M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sh705sj.ppd
+++ b/db/source/PPD/Sharp/sh705sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SH705SJ.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-705S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-705S PS"
 *ShortNickName: "Sharp AR-705S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-705S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shabc260.ppd
+++ b/db/source/PPD/Sharp/shabc260.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHABC260.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-BC260)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-BC260 PS"
 *ShortNickName: "Sharp AR-BC260 PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-BC260)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shabc320.ppd
+++ b/db/source/PPD/Sharp/shabc320.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHABC320.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-BC320)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-BC320 PS"
 *ShortNickName: "Sharp AR-BC320 PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-BC320)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shac170m.ppd
+++ b/db/source/PPD/Sharp/shac170m.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAC170M.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C170M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C170M PS"
 *ShortNickName: "Sharp AR-C170M PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C170M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shac172m.ppd
+++ b/db/source/PPD/Sharp/shac172m.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAC172M.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C172M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C172M PS"
 *ShortNickName: "Sharp AR-C172M PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C172M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shac260.ppd
+++ b/db/source/PPD/Sharp/shac260.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAC260.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C260 PS"
 *ShortNickName: "Sharp AR-C260 PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shac260m.ppd
+++ b/db/source/PPD/Sharp/shac260m.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAC260M.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C260M PS"
 *ShortNickName: "Sharp AR-C260M PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shac260p.ppd
+++ b/db/source/PPD/Sharp/shac260p.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAC260P.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260P)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C260P PS"
 *ShortNickName: "Sharp AR-C260P PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260P)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shac262m.ppd
+++ b/db/source/PPD/Sharp/shac262m.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAC262M.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C262M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C262M PS"
 *ShortNickName: "Sharp AR-C262M PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C262M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham351n.ppd
+++ b/db/source/PPD/Sharp/sham351n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM351N.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M351N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M351N PS"
 *ShortNickName: "Sharp AR-M351N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M351N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham351u.ppd
+++ b/db/source/PPD/Sharp/sham351u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM351U.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M351U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M351U PS"
 *ShortNickName: "Sharp AR-M351U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M351U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham355n.ppd
+++ b/db/source/PPD/Sharp/sham355n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM355N.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M355N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M355N PS"
 *ShortNickName: "Sharp AR-M355N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M355N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham355u.ppd
+++ b/db/source/PPD/Sharp/sham355u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM355U.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M355U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M355U PS"
 *ShortNickName: "Sharp AR-M355U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M355U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham451n.ppd
+++ b/db/source/PPD/Sharp/sham451n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM451N.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M451N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M451N PS"
 *ShortNickName: "Sharp AR-M451N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M451N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham451u.ppd
+++ b/db/source/PPD/Sharp/sham451u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM451U.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M451U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M451U PS"
 *ShortNickName: "Sharp AR-M451U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M451U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham455n.ppd
+++ b/db/source/PPD/Sharp/sham455n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM455N.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M455N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M455N PS"
 *ShortNickName: "Sharp AR-M455N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M455N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham455u.ppd
+++ b/db/source/PPD/Sharp/sham455u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM455U.PPD"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M455U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M455U PS"
 *ShortNickName: "Sharp AR-M455U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P20)"
+*Product: "(Sharp AR-M455U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham550n.ppd
+++ b/db/source/PPD/Sharp/sham550n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM550N.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M550N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M550N PS"
 *ShortNickName: "Sharp AR-M550N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M550N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham550u.ppd
+++ b/db/source/PPD/Sharp/sham550u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM550U.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M550U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M550U PS"
 *ShortNickName: "Sharp AR-M550U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M550U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham620n.ppd
+++ b/db/source/PPD/Sharp/sham620n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM620N.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M620N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M620N PS"
 *ShortNickName: "Sharp AR-M620N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M620N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham620u.ppd
+++ b/db/source/PPD/Sharp/sham620u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM620U.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M620U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M620U PS"
 *ShortNickName: "Sharp AR-M620U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M620U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham700n.ppd
+++ b/db/source/PPD/Sharp/sham700n.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM700N.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M700N)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M700N PS"
 *ShortNickName: "Sharp AR-M700N PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M700N)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sham700u.ppd
+++ b/db/source/PPD/Sharp/sham700u.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAM700U.PPD"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M700U)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M700U PS"
 *ShortNickName: "Sharp AR-M700U PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P19)"
+*Product: "(Sharp AR-M700U)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shar168d.ppd
+++ b/db/source/PPD/Sharp/shar168d.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAR168D.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-168D)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-168D PS"
 *ShortNickName: "Sharp AR-168D PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-168D)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shar168s.ppd
+++ b/db/source/PPD/Sharp/shar168s.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAR168S.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-168S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-168S PS"
 *ShortNickName: "Sharp AR-168S PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-168S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shar208d.ppd
+++ b/db/source/PPD/Sharp/shar208d.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAR208D.PPD"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-208D)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-208D PS"
 *ShortNickName: "Sharp AR-208D PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-208D)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shar208s.ppd
+++ b/db/source/PPD/Sharp/shar208s.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAR208S.PPD"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-208S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-208S PS"
 *ShortNickName: "Sharp AR-208S PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-208S)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shar5220.ppd
+++ b/db/source/PPD/Sharp/shar5220.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHAR5220.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-5220)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-5220 PS"
 *ShortNickName: "Sharp AR-5220 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-5220)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm150.ppd
+++ b/db/source/PPD/Sharp/sharm150.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM150.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M150)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M150 PS"
 *ShortNickName: "Sharp AR-M150 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M150)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm155.ppd
+++ b/db/source/PPD/Sharp/sharm155.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM155.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M155)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M155 PS"
 *ShortNickName: "Sharp AR-M155 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M155)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm160.ppd
+++ b/db/source/PPD/Sharp/sharm160.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM160.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M160)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M160 PS"
 *ShortNickName: "Sharp AR-M160 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M160)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm161.ppd
+++ b/db/source/PPD/Sharp/sharm161.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM161.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M161)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M161 PS"
 *ShortNickName: "Sharp AR-M161 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M161)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm162.ppd
+++ b/db/source/PPD/Sharp/sharm162.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM162.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M162)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M162 PS"
 *ShortNickName: "Sharp AR-M162 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M162)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm165.ppd
+++ b/db/source/PPD/Sharp/sharm165.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM165.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M165)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M165 PS"
 *ShortNickName: "Sharp AR-M165 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M165)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm200.ppd
+++ b/db/source/PPD/Sharp/sharm200.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM200.PPD"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-M200)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M200 PS"
 *ShortNickName: "Sharp AR-M200 PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-M200)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm201.ppd
+++ b/db/source/PPD/Sharp/sharm201.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM201.PPD"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-M201)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M201 PS"
 *ShortNickName: "Sharp AR-M201 PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2A)"
+*Product: "(Sharp AR-M201)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm205.ppd
+++ b/db/source/PPD/Sharp/sharm205.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM205.PPD"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M205)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M205 PS"
 *ShortNickName: "Sharp AR-M205 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB2)"
+*Product: "(Sharp AR-M205)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm206.ppd
+++ b/db/source/PPD/Sharp/sharm206.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM206.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M206)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M206 PS"
 *ShortNickName: "Sharp AR-M206 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M206)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm207.ppd
+++ b/db/source/PPD/Sharp/sharm207.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM207.PPD"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M207)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M207 PS"
 *ShortNickName: "Sharp AR-M207 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-NB3)"
+*Product: "(Sharp AR-M207)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm236.ppd
+++ b/db/source/PPD/Sharp/sharm236.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM236.PPD"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M236)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M236 PS"
 *ShortNickName: "Sharp AR-M236 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M236)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm237.ppd
+++ b/db/source/PPD/Sharp/sharm237.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM237.PPD"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M237)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M237 PS"
 *ShortNickName: "Sharp AR-M237 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M237)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm276.ppd
+++ b/db/source/PPD/Sharp/sharm276.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM276.PPD"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M276)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M276 PS"
 *ShortNickName: "Sharp AR-M276 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M276)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/sharm277.ppd
+++ b/db/source/PPD/Sharp/sharm277.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHARM277.PPD"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M277)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-M277 PS"
 *ShortNickName: "Sharp AR-M277 PS"
@@ -60,7 +60,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp AR-P17)"
+*Product: "(Sharp AR-M277)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shc260fj.ppd
+++ b/db/source/PPD/Sharp/shc260fj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHC260FJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260F)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C260F PS"
 *ShortNickName: "Sharp AR-C260F PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260F)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shc260sj.ppd
+++ b/db/source/PPD/Sharp/shc260sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHC260SJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C260S PS"
 *ShortNickName: "Sharp AR-C260S PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C260S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shc261fj.ppd
+++ b/db/source/PPD/Sharp/shc261fj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHC261FJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261F)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C261F PS"
 *ShortNickName: "Sharp AR-C261F PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261F)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shc261mj.ppd
+++ b/db/source/PPD/Sharp/shc261mj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHC261MJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261M)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C261M PS"
 *ShortNickName: "Sharp AR-C261M PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261M)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shc261sj.ppd
+++ b/db/source/PPD/Sharp/shc261sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHC261SJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C261S PS"
 *ShortNickName: "Sharp AR-C261S PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C261S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shc262sj.ppd
+++ b/db/source/PPD/Sharp/shc262sj.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHC262SJ.PPD"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C262S)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp AR-C262S PS"
 *ShortNickName: "Sharp AR-C262S PS"
@@ -156,7 +156,7 @@
 *End
 
 *Password: "(0)"
-*Product: "(Sharp AR-PK4)"
+*Product: "(Sharp AR-C262S)"
 *Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shmb201d.ppd
+++ b/db/source/PPD/Sharp/shmb201d.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHMB201D.PPD"
-*Product: "(Sharp MX-NB11)"
+*Product: "(Sharp MX-B201D)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp MX-B201D PS"
 *ShortNickName: "Sharp MX-B201D PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp MX-NB11)"
+*Product: "(Sharp MX-B201D)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "

--- a/db/source/PPD/Sharp/shmxb201.ppd
+++ b/db/source/PPD/Sharp/shmxb201.ppd
@@ -24,7 +24,7 @@
 *LanguageVersion: English
 *LanguageEncoding: ISOLatin1
 *PCFileName: "SHMXB201.PPD"
-*Product: "(Sharp MX-NB11)"
+*Product: "(Sharp MX-B201)"
 *Manufacturer: "Sharp"
 *ModelName: "Sharp MX-B201 PS"
 *ShortNickName: "Sharp MX-B201 PS"
@@ -60,7 +60,7 @@
 *%JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT <0A>"
 *JobPatchFile 1: "<</DeferredMediaSelection true /MediaPosition 9 /ManualFeed false>> setpagedevice"
 *Password: "(0)"
-*Product: "(Sharp MX-NB11)"
+*Product: "(Sharp MX-B201)"
 *%Protocols: PJL
 *RequiresPageRegion All: True
 *Reset: "


### PR DESCRIPTION
The product values in some Sharp PPDs were used in multiple PPD files
and referred to non-existent printers. This change updates the Product
field of these PPDs to use the same value as the ModelName field.