### PR TITLE
Change ColorMode to ColorModel so CUPS recognizes it as a standard value

### DIFF
--- a/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -489,8 +489,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
@@ -185,7 +185,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -830,8 +830,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
@@ -186,7 +186,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
@@ -184,7 +184,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
@@ -182,12 +182,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -830,8 +830,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
@@ -205,12 +205,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -859,8 +859,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
@@ -208,7 +208,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -859,8 +859,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
@@ -209,7 +209,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
@@ -207,7 +207,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
@@ -201,7 +201,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -856,10 +856,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
-*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel Gray
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
@@ -202,7 +202,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
@@ -198,12 +198,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -856,10 +856,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization Black
-*UIConstraints: *ColorMode False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorMode False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
@@ -200,7 +200,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -436,10 +436,10 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 
 *% =========================================================
-*%  ColorMode - BlackOptimization
+*%  ColorModel - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -438,8 +438,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  ColorModel - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -436,10 +436,10 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 
 *% =========================================================
-*%  ColorMode - BlackOptimization
+*%  ColorModel - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -438,8 +438,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  ColorModel - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
@@ -476,12 +476,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *%========================================================
 *% JCLRGB Color Intent
@@ -841,8 +841,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
@@ -478,7 +478,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
@@ -479,7 +479,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -841,8 +841,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C4820_Series.ppd
@@ -480,7 +480,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *%========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_C48x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C48x_Series.ppd
@@ -68,12 +68,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: CMYK
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel CMYK/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -446,8 +446,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  ColorMode - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel Gray *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_C48x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C48x_Series.ppd
@@ -444,7 +444,7 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 
 *% =========================================================
-*%  ColorMode - BlackOptimization
+*%  ColorModel - BlackOptimization
 *% =========================================================
 *UIConstraints: *ColorModel Gray *JCLBlackOptimization True
 *UIConstraints: *JCLBlackOptimization True  *ColorModel Gray

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
@@ -73,11 +73,11 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Paper Source

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
@@ -75,7 +75,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
@@ -76,7 +76,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-350_Series.ppd
@@ -74,7 +74,7 @@
 *%  Color & Gray Option
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -493,8 +493,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -493,8 +493,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
@@ -73,11 +73,11 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Paper Source

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
@@ -75,7 +75,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
@@ -76,7 +76,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-660_Series.ppd
@@ -74,7 +74,7 @@
 *%  Color & Gray Option
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
@@ -88,7 +88,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
@@ -89,7 +89,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -445,8 +445,8 @@ save currentpagedevice /PageSize get aload pop
 *UIConstraints: *SECReverseDuplex True      *Duplex None
 
 *%======Color Mode - Black Optimization
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
@@ -90,7 +90,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
@@ -86,12 +86,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -445,8 +445,8 @@ save currentpagedevice /PageSize get aload pop
 *UIConstraints: *SECReverseDuplex True      *Duplex None
 
 *%======Color Mode - Black Optimization
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
@@ -171,7 +171,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
@@ -172,7 +172,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -800,8 +800,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
@@ -173,7 +173,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
@@ -169,12 +169,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -800,8 +800,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
@@ -87,12 +87,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Paper Source

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
@@ -91,7 +91,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
@@ -89,7 +89,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
@@ -90,7 +90,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
@@ -87,12 +87,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Paper Source

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
@@ -91,7 +91,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
@@ -89,7 +89,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
@@ -90,7 +90,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -439,8 +439,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  ColorModel - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -437,10 +437,10 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 
 *% =========================================================
-*%  ColorMode - BlackOptimization
+*%  ColorModel - BlackOptimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  PageSize PostCard 4x6 - Media Type

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
@@ -71,7 +71,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
@@ -73,7 +73,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
@@ -69,12 +69,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -493,8 +493,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
@@ -72,7 +72,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -493,8 +493,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Envelope(PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
@@ -89,12 +89,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =======================================================================================
 *%  Darken Text

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
@@ -93,7 +93,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =======================================================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
@@ -92,7 +92,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
@@ -91,7 +91,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
@@ -88,7 +88,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
@@ -86,12 +86,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -443,8 +443,8 @@ save currentpagedevice /PageSize get aload pop
 *UIConstraints: *SECReverseDuplex True      *Duplex None
 
 *%======Color Mode - Black Optimization
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
@@ -89,7 +89,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -443,8 +443,8 @@ save currentpagedevice /PageSize get aload pop
 *UIConstraints: *SECReverseDuplex True      *Duplex None
 
 *%======Color Mode - Black Optimization
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
@@ -90,7 +90,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
@@ -93,7 +93,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
@@ -94,7 +94,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =======================================================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
@@ -92,7 +92,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
@@ -90,12 +90,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =======================================================================================
 *%  Darken Text

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
@@ -88,7 +88,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
@@ -86,12 +86,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -443,8 +443,8 @@ save currentpagedevice /PageSize get aload pop
 *UIConstraints: *SECReverseDuplex True      *Duplex None
 
 *%======Color Mode - Black Optimization
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
@@ -89,7 +89,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -443,8 +443,8 @@ save currentpagedevice /PageSize get aload pop
 *UIConstraints: *SECReverseDuplex True      *Duplex None
 
 *%======Color Mode - Black Optimization
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
@@ -90,7 +90,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
@@ -169,12 +169,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  Boolean
-*OrderDependency: 70 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  Boolean
+*OrderDependency: 70 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -798,8 +798,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
@@ -171,7 +171,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
@@ -173,7 +173,7 @@
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
@@ -172,7 +172,7 @@
 *OpenUI *ColorModel/Color Mode:  Boolean
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:       "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -798,8 +798,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *%  Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  Duplex - PageSize

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
@@ -122,7 +122,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
@@ -121,7 +121,7 @@
 *%  Color & Gray Option
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
@@ -123,7 +123,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =======================================================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8380_Series.ppd
@@ -120,11 +120,11 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =======================================================================================
 *%  Darken Text

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
@@ -187,12 +187,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *%========================================================
 *% JCLRGB

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
@@ -190,7 +190,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
@@ -191,7 +191,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *%========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385X_Series.ppd
@@ -189,7 +189,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
@@ -187,12 +187,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *%========================================================
 *% JCLRGB

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
@@ -190,7 +190,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
@@ -191,7 +191,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *%========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8385_Series.ppd
@@ -189,7 +189,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
@@ -191,7 +191,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color:      "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color:      "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *%========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
@@ -190,7 +190,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:      "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
@@ -189,7 +189,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color:      "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8540_Series.ppd
@@ -187,12 +187,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color:      "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color:      "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *%========================================================
 *% JCLRGB

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
@@ -477,7 +477,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
@@ -475,12 +475,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -923,8 +923,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *% Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *% Finisher - Staple, Sort

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
@@ -478,7 +478,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -923,8 +923,8 @@ save currentpagedevice /PageSize get aload pop
 *% =========================================================
 *% Color Mode - Black Optimization
 *% =========================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *% Finisher - Staple, Sort

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-8640_8650_Series.ppd
@@ -479,7 +479,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
@@ -175,7 +175,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
@@ -172,12 +172,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *%========================================================
 *% JCLRGB Color Intent

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
@@ -174,7 +174,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9250_9350_Series.ppd
@@ -176,7 +176,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *%========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
@@ -303,7 +303,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
@@ -301,12 +301,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
@@ -304,7 +304,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-9252_9352_Series.ppd
@@ -305,7 +305,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
@@ -278,7 +278,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
@@ -276,12 +276,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -955,8 +955,8 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
@@ -280,7 +280,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-92x1_93x1_Series.ppd
@@ -279,7 +279,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -955,8 +955,8 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
@@ -278,7 +278,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
@@ -276,12 +276,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -955,8 +955,8 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel False
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
@@ -280,7 +280,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-981x_Series.ppd
@@ -279,7 +279,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -955,8 +955,8 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization True
-*UIConstraints: *JCLBlackOptimization True  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization True
+*UIConstraints: *JCLBlackOptimization True  *ColorModel Gray
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
@@ -303,7 +303,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
@@ -301,12 +301,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
@@ -304,7 +304,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-982x_Series.ppd
@@ -305,7 +305,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
@@ -298,7 +298,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -1100,10 +1100,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
-*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel Gray
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel Gray
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
@@ -299,7 +299,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
@@ -295,12 +295,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -1100,10 +1100,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization Black
-*UIConstraints: *ColorMode False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorMode False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X3220_Series.ppd
@@ -297,7 +297,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
@@ -284,12 +284,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -1146,10 +1146,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization Black
-*UIConstraints: *ColorMode False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorMode False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
@@ -287,7 +287,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -1146,10 +1146,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
-*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel Gray
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel Gray
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
@@ -288,7 +288,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X401_Series.ppd
@@ -286,7 +286,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
@@ -284,12 +284,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -1146,10 +1146,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization Black
-*UIConstraints: *ColorMode False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorMode False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
@@ -287,7 +287,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -1146,10 +1146,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
-*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel Gray
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel Gray
 
 *% =========================================================
 *%  PostCard (PageSize) - MediaType

--- a/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
@@ -288,7 +288,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X4300_Series.ppd
@@ -286,7 +286,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
@@ -321,7 +321,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
@@ -317,12 +317,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -1373,10 +1373,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization Black
-*UIConstraints: *ColorMode False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorMode False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
 
 *% =========================================================
 *%  Reverse Duplex - Duplex

--- a/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
@@ -319,7 +319,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X703_Series.ppd
@@ -320,7 +320,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -1373,10 +1373,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
-*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel Gray
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel Gray
 
 *% =========================================================
 *%  Reverse Duplex - Duplex

--- a/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
@@ -321,7 +321,7 @@
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
 *ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
 *% =========================================================

--- a/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
@@ -317,12 +317,12 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorMode/Color Mode:  PickOne
-*OrderDependency: 20 AnySetup *ColorMode
-*DefaultColorMode: True
-*ColorMode False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
-*ColorMode True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
-*CloseUI: *ColorMode
+*OpenUI *ColorModel/Color Mode:  PickOne
+*OrderDependency: 20 AnySetup *ColorModel
+*DefaultColorModel: True
+*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel True/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
+*CloseUI: *ColorModel
 
 *% =========================================================
 *%  Black Optimization
@@ -1373,10 +1373,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorMode False            *JCLBlackOptimization Black
-*UIConstraints: *ColorMode False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorMode False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorMode False
+*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
 
 *% =========================================================
 *%  Reverse Duplex - Duplex

--- a/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
@@ -319,7 +319,7 @@
 *% =========================================================
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
-*DefaultColorModel: True
+*DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel

--- a/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_X7600_Series.ppd
@@ -320,7 +320,7 @@
 *OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 20 AnySetup *ColorModel
 *DefaultColorModel: True
-*ColorModel False/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
+*ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"
 *ColorModel Color/Color: "<</ProcessColorModel /DeviceCMYK>> setpagedevice"
 *CloseUI: *ColorModel
 
@@ -1373,10 +1373,10 @@ save currentpagedevice /PageSize get aload pop
 *% ===============================================================
 *% Color Mode - Black Optimization
 *% ===============================================================
-*UIConstraints: *ColorModel False            *JCLBlackOptimization Black
-*UIConstraints: *ColorModel False            *JCLBlackOptimization KCMY
-*UIConstraints: *JCLBlackOptimization Black  *ColorModel False
-*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel False
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization Black
+*UIConstraints: *ColorModel Gray            *JCLBlackOptimization KCMY
+*UIConstraints: *JCLBlackOptimization Black  *ColorModel Gray
+*UIConstraints: *JCLBlackOptimization KCMY  *ColorModel Gray
 
 *% =========================================================
 *%  Reverse Duplex - Duplex


### PR DESCRIPTION
We noticed that color selection was not working for this printer when using the CUPS IPP API.  This should fix it.