### PR TITLE
Change OpenUI type to PickOne from Boolean

### DIFF
--- a/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C140x_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C145x_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1810_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C1860_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2620_Series.ppd
@@ -182,7 +182,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C2670_Series.ppd
@@ -205,7 +205,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C268x_Series.ppd
@@ -198,7 +198,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C460_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_C470_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-410_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-670_Series.ppd
@@ -86,7 +86,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-680_Series.ppd
@@ -169,7 +169,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-770_Series.ppd
@@ -87,7 +87,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLP-775_Series.ppd
@@ -87,7 +87,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-3300_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-4190_Series.ppd
@@ -69,7 +69,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6200_Series.ppd
@@ -89,7 +89,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6220_Series.ppd
@@ -86,7 +86,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6240_Series.ppd
@@ -90,7 +90,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale: "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6250_Series.ppd
@@ -86,7 +86,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"

--- a/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
+++ b/db/source/PPD/Samsung/PS/Samsung_CLX-6260_Series.ppd
@@ -169,7 +169,7 @@
 *% =========================================================
 *%  Color & Gray Option
 *% =========================================================
-*OpenUI *ColorModel/Color Mode:  Boolean
+*OpenUI *ColorModel/Color Mode:  PickOne
 *OrderDependency: 70 AnySetup *ColorModel
 *DefaultColorModel: Color
 *ColorModel Gray/Grayscale:  "<</ProcessColorModel /DeviceGray>> setpagedevice"


### PR DESCRIPTION
For certain Samung PS PPDs, ColorMode values were updated to ColorModel.  To match expectations by CUPS, options were renamed to Gray and Color.  This is not compatible with the Boolean OpenUI type, it should be PickOne.