### PR TITLE
[Implement] Automatic tagging if there are any commits in the past 24 hours.

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Set Date as Tag
         run: |
           TAG_NAME=$(date '+%Y-%m-%d')
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
           if [ -n "$(git log --since="24 hours ago" --pretty=format:'%h')" ]; then
             git tag -a $TAG_NAME
             git push origin $TAG_NAME

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -3,7 +3,7 @@ name: Create Tag on Each Date if Any Commit
 on:
   schedule:
     # Run daily
-    - cron: '0 0 * * *'
+    - cron: '29 6 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,25 @@
+name: Create Tag on Each Date if Any Commit
+
+on:
+  schedule:
+    # Run daily
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set Date as Tag
+        run: |
+          TAG_NAME=$(date '+%Y-%m-%d')
+          if [ -n "$(git log --since="24 hours ago" --pretty=format:'%h')" ]; then
+            git tag -a $TAG_NAME
+            git push origin $TAG_NAME
+          else
+            echo "No commits in the last 24 hours. Skipping tag creation."
+          fi

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Set Date as Tag
         run: |
-          TAG_NAME=$(date '+%Y-%m-%d')
+          TAG_NAME=$(date '+%Y%m%d')
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           if [ -n "$(git log --since="24 hours ago" --pretty=format:'%h')" ]; then

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           if [ -n "$(git log --since="24 hours ago" --pretty=format:'%h')" ]; then
-            git tag -a $TAG_NAME
+            git tag -a $TAG_NAME -m "Tag for $TAG_NAME"
             git push origin $TAG_NAME
           else
             echo "No commits in the last 24 hours. Skipping tag creation."


### PR DESCRIPTION
- I have introduced the "create-tag.yml" workflow, scheduled to execute daily at 12:00 am. This workflow examines the presence of commits within the last 24 hours. If such commits exist, it generates a corresponding tag with the respective date; however, in the absence of recent commits, the process refrains from creating a tag.