### PR TITLE
Add Lexmark C3200 Series / C3224dw printer 

### DIFF
--- a/db/source/printer/Lexmark-C3200.xml
+++ b/db/source/printer/Lexmark-C3200.xml
@@ -1,0 +1,51 @@
+<printer id="printer/Lexmark-C3200">
+  <make>Lexmark</make>
+  <model>C3200</model>
+  <mechanism>
+    <color />
+  </mechanism>
+  <lang>
+    <pcl level="6" />
+    <postscript level="3" />
+    <pjl />
+    <text>
+      <charset>us-ascii</charset>
+    </text>
+  </lang>
+  <autodetect>
+    <general>
+      <ieee1284>MFG:Lexmark ;MDL:Lexmark C3200 Series;</ieee1284>
+      <manufacturer>Lexmark </manufacturer>
+      <model>Lexmark C3200 Series</model>
+    </general>
+  </autodetect>
+  <functionality>A</functionality>
+  <driver>Postscript-Lexmark</driver>
+  <drivers>
+    <driver>
+      <id>hpijs-pcl5e</id>
+    </driver>
+    <driver>
+      <id>lj5gray</id>
+    </driver>
+    <driver>
+      <id>ljet4</id>
+    </driver>
+    <driver>
+      <id>ljet4d</id>
+    </driver>
+    <driver>
+      <id>Postscript</id>
+    </driver>
+    <driver>
+      <id>Postscript-Lexmark</id>
+      <ppd>PPD/Lexmark/Lexmark_C9200_Series.ppd</ppd>
+    </driver>
+    <driver>
+      <id>pxlcolor</id>
+    </driver>
+    <driver>
+      <id>pxlmono</id>
+    </driver>
+  </drivers>
+</printer>

--- a/db/source/printer/Lexmark-C3224dw.xml
+++ b/db/source/printer/Lexmark-C3224dw.xml
@@ -1,0 +1,51 @@
+<printer id="printer/Lexmark-C3224dw">
+  <make>Lexmark</make>
+  <model>C3224dw</model>
+  <mechanism>
+    <color />
+  </mechanism>
+  <lang>
+    <pcl level="6" />
+    <postscript level="3" />
+    <pjl />
+    <text>
+      <charset>us-ascii</charset>
+    </text>
+  </lang>
+  <autodetect>
+    <general>
+      <ieee1284>MFG:Lexmark ;MDL:Lexmark C3224dw;</ieee1284>
+      <manufacturer>Lexmark </manufacturer>
+      <model>Lexmark C3224dw</model>
+    </general>
+  </autodetect>
+  <functionality>A</functionality>
+  <driver>Postscript-Lexmark</driver>
+  <drivers>
+    <driver>
+      <id>hpijs-pcl5e</id>
+    </driver>
+    <driver>
+      <id>lj5gray</id>
+    </driver>
+    <driver>
+      <id>ljet4</id>
+    </driver>
+    <driver>
+      <id>ljet4d</id>
+    </driver>
+    <driver>
+      <id>Postscript</id>
+    </driver>
+    <driver>
+      <id>Postscript-Lexmark</id>
+      <ppd>PPD/Lexmark/Lexmark_C9200_Series.ppd</ppd>
+    </driver>
+    <driver>
+      <id>pxlcolor</id>
+    </driver>
+    <driver>
+      <id>pxlmono</id>
+    </driver>
+  </drivers>
+</printer>


### PR DESCRIPTION
Add support for the Lexmark C3200 Series, in particular the Lexmark C3224dw printer.