### PR TITLE
Update foo2zjs driver suite metadata: Migrate from dead rkkda upstream

### DIFF
--- a/db/source/driver/foo2zjs-z1.xml
+++ b/db/source/driver/foo2zjs-z1.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs-z1">
   <name>foo2zjs-z1</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2zjs-z2.xml
+++ b/db/source/driver/foo2zjs-z2.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs-z2">
   <name>foo2zjs-z2</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2zjs-z3.xml
+++ b/db/source/driver/foo2zjs-z3.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs-z3">
   <name>foo2zjs-z3</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2zjs.xml
+++ b/db/source/driver/foo2zjs.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs">
   <name>foo2zjs</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />


### PR DESCRIPTION
**Changes:**
- Updated the `<url>` tags in all `foo2*.xml` driver files (foo2zjs, foo2hp, foo2lava, etc.).
- Replaced the dead upstream link (`http://foo2zjs.rkkda.com/`) with the active OpenPrinting GitHub repository (`https://github.com/OpenPrinting/foo2zjs`).

**Reason:**
The original upstream website (rkkda.com) is no longer available. OpenPrinting has adopted this driver suite, and the GitHub repository is now the correct canonical source for these drivers.