### PR TITLE
Update InfoPrint driver metadata: Fix dead manufacturer URL

### DIFF
--- a/db/source/driver/Postscript-InfoPrint.xml
+++ b/db/source/driver/Postscript-InfoPrint.xml
@@ -1,6 +1,6 @@
 <driver id="driver/Postscript-InfoPrint">
   <name>Postscript-InfoPrint</name>
-  <url>http://www.infoprintsolutionscompany.com/</url>
+  <url>https://www.openprinting.org/printers/manufacturer/InfoPrint</url>
   <supplier>Ricoh</supplier>
   <manufacturersupplied>InfoPrint</manufacturersupplied>
   <license>MIT</license>

--- a/db/source/driver/pxlcolor-InfoPrint.xml
+++ b/db/source/driver/pxlcolor-InfoPrint.xml
@@ -1,6 +1,6 @@
 <driver id="driver/pxlcolor-InfoPrint">
   <name>pxlcolor-InfoPrint</name>
-  <url>http://www.infoprintsolutionscompany.com/</url>
+  <url>https://www.openprinting.org/printers/manufacturer/InfoPrint</url>
   <supplier>Ricoh</supplier>
   <manufacturersupplied>InfoPrint</manufacturersupplied>
   <license>MIT</license>

--- a/db/source/driver/pxlmono-InfoPrint.xml
+++ b/db/source/driver/pxlmono-InfoPrint.xml
@@ -1,6 +1,6 @@
 <driver id="driver/pxlmono-InfoPrint">
   <name>pxlmono-InfoPrint</name>
-  <url>http://www.infoprintsolutionscompany.com/</url>
+  <url>https://www.openprinting.org/printers/manufacturer/InfoPrint</url>
   <supplier>Ricoh</supplier>
   <manufacturersupplied>InfoPrint</manufacturersupplied>
   <license>MIT</license>


### PR DESCRIPTION
**Changes:**
- Updated the `<url>` tags in `Postscript-InfoPrint.xml`, `pxlcolor-InfoPrint.xml`, and `pxlmono-InfoPrint.xml`.
- Replaced the dead manufacturer link (`http://www.infoprintsolutionscompany.com/`) with the OpenPrinting Manufacturer archive page (`https://www.openprinting.org/printers/manufacturer/InfoPrint`).

**Reason:**
The InfoPrint Solutions Company website is no longer active (the company was acquired and the domain is dead). Since no direct upstream source exists for these legacy drivers, pointing to the OpenPrinting manufacturer category serves as the correct archival reference for users.