### PR TITLE
Update URL for foo2zjs driver

### DIFF
--- a/db/source/driver/foo2zjs.xml
+++ b/db/source/driver/foo2zjs.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs">
   <name>foo2zjs</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />


### PR DESCRIPTION
Updated the Url of Foo2zjs Driver to redirect to original repo rather than the broken link. 