### PR TITLE
Fix and standardize upstream URLs for foo2* driver family

### DIFF
--- a/db/source/driver/foo2hbpl2.xml
+++ b/db/source/driver/foo2hbpl2.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2hbpl2">
   <name>foo2hbpl2</name>
-  <url>http://foo2hbpl.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2hiperc-z1.xml
+++ b/db/source/driver/foo2hiperc-z1.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2hiperc-z1">
   <name>foo2hiperc-z1</name>
-  <url>http://foo2hiperc.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2hiperc.xml
+++ b/db/source/driver/foo2hiperc.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2hiperc">
   <name>foo2hiperc</name>
-  <url>http://foo2hiperc.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2hp.xml
+++ b/db/source/driver/foo2hp.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2hp">
   <name>foo2hp</name>
-  <url>http://foo2hp.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2lava.xml
+++ b/db/source/driver/foo2lava.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2lava">
   <name>foo2lava</name>
-  <url>http://foo2lava.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2oak-z1.xml
+++ b/db/source/driver/foo2oak-z1.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2oak-z1">
   <name>foo2oak-z1</name>
-  <url>http://foo2oak.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2oak.xml
+++ b/db/source/driver/foo2oak.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2oak">
   <name>foo2oak</name>
-  <url>http://foo2oak.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2qpdl.xml
+++ b/db/source/driver/foo2qpdl.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2qpdl">
   <name>foo2qpdl</name>
-  <url>http://foo2qpdl.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2slx.xml
+++ b/db/source/driver/foo2slx.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2slx">
   <name>foo2slx</name>
-  <url>http://foo2slx.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2xqx.xml
+++ b/db/source/driver/foo2xqx.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2xqx">
   <name>foo2xqx</name>
-  <url>http://foo2xqx.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2zjs-z1.xml
+++ b/db/source/driver/foo2zjs-z1.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs-z1">
   <name>foo2zjs-z1</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2zjs-z2.xml
+++ b/db/source/driver/foo2zjs-z2.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs-z2">
   <name>foo2zjs-z2</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />

--- a/db/source/driver/foo2zjs-z3.xml
+++ b/db/source/driver/foo2zjs-z3.xml
@@ -1,6 +1,6 @@
 <driver id="driver/foo2zjs-z3">
   <name>foo2zjs-z3</name>
-  <url>http://foo2zjs.rkkda.com/</url>
+  <url>https://github.com/OpenPrinting/foo2zjs</url>
   <thirdpartysupplied />
   <execution>
     <filter />


### PR DESCRIPTION
This PR reviews and corrects the upstream URLs for the foo2* driver entries in foomatic-db.

Changes made:

• Updated foo2zjs-based drivers to point to the current OpenPrinting upstream repository.
• Ensured that variants sharing the same codebase reference the same upstream for consistency.
• Left foo2kyo (kyo-fs1016mfp) pointing to its original SourceForge project, since it is a separate upstream project (last updated 2015) and not part of the foo2zjs codebase.
• Replaced outdated or dead links where applicable, without changing driver functionality.

This PR is limited strictly to metadata corrections and does not modify PPD generation or driver behavior.
